### PR TITLE
Fix several bugs in network setup, config writes and update flow

### DIFF
--- a/files/initrd/opt/rr/include/configFile.sh
+++ b/files/initrd/opt/rr/include/configFile.sh
@@ -21,7 +21,10 @@ function deleteConfigKey() {
 # 3 - Path of yaml config file
 function writeConfigKey() {
   local value="${2}"
-  [ "${value}" = "{}" ] && yq eval ".${1} = {}" --inplace "${3}" 2>/dev/null || yq eval ".${1} = \"${value}\"" --inplace "${3}" 2>/dev/null
+  # The value is data, not part of the expression: interpolating it lets a quote in
+  # a serial, password or webhook url break the yq expression (silently losing the
+  # write) or inject further yq operators. strenv() passes it through untouched.
+  [ "${value}" = "{}" ] && yq eval ".${1} = {}" --inplace "${3}" 2>/dev/null || VALUE="${value}" yq eval ".${1} = strenv(VALUE)" --inplace "${3}" 2>/dev/null
 }
 
 ###############################################################################

--- a/files/initrd/opt/rr/include/functions.py
+++ b/files/initrd/opt/rr/include/functions.py
@@ -62,7 +62,9 @@ def _resolve_and_set_hosts(domain):
         ret = subprocess.run(
             ["ping", "-c", "1", "-W", "1", domain],
             capture_output=True, text=True, timeout=5,
-            env={"LC_ALL": "C"}
+            # Passing a bare dict would replace the whole environment, so PATH is
+            # lost and only os.defpath is searched for the ping binary.
+            env={**os.environ, "LC_ALL": "C"}
         )
         if ret.returncode == 0:
             return True  # Already reachable
@@ -77,11 +79,25 @@ def _resolve_and_set_hosts(domain):
             for ans in data.get("Answer", []):
                 if ans.get("type") == 1:
                     ip = ans["data"]
-                    escaped = domain.replace(".", "\\.")
-                    subprocess.run(
-                        ["sed", "-i", f"/[[:space:]]{escaped}[[:space:]]*$/d", "/etc/hosts"],
-                        capture_output=True, timeout=5
-                    )
+                    # Drop stale entries for this domain, otherwise they keep
+                    # shadowing the one appended below. The name is compared field by
+                    # field rather than through a regex so that a dot cannot act as a
+                    # wildcard and take unrelated hosts with it. Comments are kept.
+                    try:
+                        with open("/etc/hosts", "r") as f:
+                            lines = f.readlines()
+                        kept = [
+                            l for l in lines
+                            if l.lstrip().startswith("#") or domain not in l.split()[1:]
+                        ]
+                        # A last line without a newline would be merged with ours.
+                        if kept and not kept[-1].endswith("\n"):
+                            kept[-1] += "\n"
+                        if kept != lines:
+                            with open("/etc/hosts", "w") as f:
+                                f.writelines(kept)
+                    except OSError:
+                        pass
                     with open("/etc/hosts", "a") as f:
                         f.write(f"{ip:<16s}{domain}\n")
                     return True

--- a/files/initrd/opt/rr/include/functions.sh
+++ b/files/initrd/opt/rr/include/functions.sh
@@ -251,30 +251,54 @@ function _get_platform() {
 }
 
 ###############################################################################
-# Get platform
+# Resolve a domain over DoH and pin the result in /etc/hosts
 # 1 - domain
 function _resolve_and_set_hosts() {
-  __setHosts() {
-    local IP="${1}"
-    local DOMAIN="${2}"
-    [ -z "${IP}" ] || [ -z "${DOMAIN}" ] && return 1
-    # Remove existing entry for this domain
-    sed -i "/[[:space:]]${DOMAIN//./\\.}[[:space:]]*$/d" /etc/hosts 2>/dev/null || true
-    # Add new entry
-    printf '%- 16s%s\n' "${IP}" "${DOMAIN}" | tee -a /etc/hosts >/dev/null 2>&1
-    return 0
-  }
   local DOMAIN="${1}"
   local IP=""
   [ -z "${DOMAIN}" ] && return 1
-  LC_ALL=C ping -c 1 -W 1 "${DOMAIN}" >/dev/null 2>&1 && return 0
+  # 'ping -W' only bounds the ICMP reply wait, not the name lookup: with a dead
+  # nameserver getaddrinfo blocks for timeout*attempts (~10s) before ping even
+  # starts. Cap the whole probe so the DoH fallback below is reached promptly.
+  LC_ALL=C timeout 2 ping -c 1 -W 1 "${DOMAIN}" >/dev/null 2>&1 && return 0
   # Try Cloudflare DoH
   [ -z "${IP}" ] && IP="$(curl -skL --connect-timeout 5 "https://cloudflare-dns.com/dns-query?name=${DOMAIN}&type=A" -H "accept: application/dns-json" 2>/dev/null | jq -r '.Answer[]? | select(.type == 1) | .data' 2>/dev/null | head -1)"
   # Try Google DoH
   [ -z "${IP}" ] && IP="$(curl -skL --connect-timeout 5 "https://dns.google/resolve?name=${DOMAIN}&type=A" 2>/dev/null | jq -r '.Answer[]? | select(.type == 1) | .data' 2>/dev/null | head -1)"
   # Try AliDNS
   [ -z "${IP}" ] && IP="$(curl -skL --connect-timeout 5 "https://dns.alidns.com/resolve?name=${DOMAIN}&type=A" 2>/dev/null | jq -r '.Answer[]? | select(.type == 1) | .data' 2>/dev/null | head -1)"
-  [ -n "${IP}" ] && __setHosts "${IP}" "${DOMAIN}"
+  [ -n "${IP}" ] && _set_hosts "${IP}" "${DOMAIN}"
+  return 0
+}
+
+###############################################################################
+# Pin an ip/domain pair in /etc/hosts, replacing any previous entry
+# 1 - ip
+# 2 - domain
+function _set_hosts() {
+  local IP="${1}"
+  local DOMAIN="${2}"
+  local TF=""
+  [ -z "${IP}" ] || [ -z "${DOMAIN}" ] && return 1
+  # Drop every existing entry for this domain. The name is compared field by field
+  # instead of being interpolated into a regex: bash strips the backslash out of
+  # "${DOMAIN//./\\.}", so the dots stayed live wildcards and pinning
+  # www.synology.com would also delete an unrelated wwwXsynologyYcom. Aliases after
+  # the canonical name count as a match, comment lines never do.
+  TF="$(mktemp 2>/dev/null)" || TF=""
+  TF="${TF:-/tmp/hosts.$$}"
+  if [ -f /etc/hosts ] && awk -v d="${DOMAIN}" '
+    /^[[:space:]]*#/ { print; next }
+    { for (i = 2; i <= NF; i++) if ($i == d) next } 1
+  ' /etc/hosts >"${TF}" 2>/dev/null; then
+    cat "${TF}" >/etc/hosts 2>/dev/null || true # Truncate in place to keep the inode
+  fi
+  rm -f "${TF}" 2>/dev/null || true
+  # A file whose last line has no newline would otherwise be merged with ours
+  if [ -s /etc/hosts ] && [ -n "$(tail -c 1 /etc/hosts 2>/dev/null)" ]; then
+    echo "" >>/etc/hosts 2>/dev/null || true
+  fi
+  printf '%-16s%s\n' "${IP}" "${DOMAIN}" >>/etc/hosts 2>/dev/null || true
   return 0
 }
 
@@ -296,12 +320,18 @@ function _get_fastest() {
       speedlist+="${I} ${speed:-999}\n" # Assign default value 999 if speed is empty
     done
   fi
-  local fastest
+  local fastest URL SPD
   fastest="$(echo -e "${speedlist}" | tr -s '\n' | awk '$2 != "999"' | sort -k2n | head -1)"
   URL="$(echo "${fastest}" | awk '{print $1}')"
   SPD="$(echo "${fastest}" | awk '{print $2}')" # It is a float type
   echo "${URL:-${1}}"
-  [ "$(echo "${SPD:-999}" | cut -d'.' -f1)" -ge 999 ] && return 1 || return 0
+  # Keep only the integer part, and treat anything non-numeric as a failure so
+  # that a garbled measurement is not reported as success.
+  SPD="$(echo "${SPD:-999}" | cut -d'.' -f1)"
+  case "${SPD}" in
+    '' | *[!0-9]*) return 1 ;;
+  esac
+  [ "${SPD}" -ge 999 ] && return 1 || return 0
 }
 
 ###############################################################################
@@ -319,23 +349,29 @@ function _sort_netif() {
   done
   ETHLISTTMPM=""
   ETHLISTTMPB="$(echo -e "${ETHLIST}" | sort -V)"
+  # init.sh runs with 'set -e' and a grep that matches nothing exits 1, which in an
+  # assignment is the status of the whole command: an unmatched mac in the sortnetif
+  # list, or no interfaces at all, would abort the boot here. Keep every grep quiet.
   if [ -n "${1}" ]; then
     MACS="$(echo "${1}" | sed 's/://g; s/,/ /g; s/.*/\L&/')"
     for MACX in ${MACS}; do
-      ETHLISTTMPM="${ETHLISTTMPM}$(echo -e "${ETHLISTTMPB}" | grep "${MACX}")\n"
-      ETHLISTTMPB="$(echo -e "${ETHLISTTMPB}" | grep -v "${MACX}")\n"
+      ETHLISTTMPM="${ETHLISTTMPM}$(echo -e "${ETHLISTTMPB}" | grep "${MACX}" || true)\n"
+      ETHLISTTMPB="$(echo -e "${ETHLISTTMPB}" | grep -v "${MACX}" || true)\n"
     done
   fi
-  ETHLIST="$(echo -e "${ETHLISTTMPM}${ETHLISTTMPB}" | grep -v '^$')"
+  ETHLIST="$(echo -e "${ETHLISTTMPM}${ETHLISTTMPB}" | grep -v '^$' || true)"
   ETHSEQ="$(echo -e "${ETHLIST}" | awk '{print $3}' | sed 's/eth//g')"
-  ETHNUM="$(echo -e "${ETHLIST}" | wc -l)"
+  # 'echo -e "" | wc -l' is 1, so count the non-empty lines instead: an empty
+  # ETHLIST must yield 0 or the block below renames interfaces that do not exist.
+  # awk is used rather than 'grep -c' because it still exits 0 on a zero count.
+  ETHNUM="$(echo -e "${ETHLIST}" | awk 'NF{c++} END{print c+0}')"
 
   # echo "${ETHSEQ}"
   # sort
-  if [ ! "${ETHSEQ}" = "$(seq 0 $((${ETHNUM:0} - 1)))" ]; then
+  if [ "${ETHNUM:-0}" -gt 0 ] && [ ! "${ETHSEQ}" = "$(seq 0 $((${ETHNUM:-0} - 1)))" ]; then
     /etc/init.d/S41dhcpcd stop >/dev/null 2>&1
     /etc/init.d/S40network stop >/dev/null 2>&1
-    for i in $(seq 0 $((${ETHNUM:0} - 1))); do
+    for i in $(seq 0 $((${ETHNUM:-0} - 1))); do
       ip link set dev "eth${i}" name "tmp${i}"
     done
     I=0
@@ -370,10 +406,10 @@ function getBus() {
 function getIP() {
   local IP=""
   if [ -n "${1}" ] && [ -d "/sys/class/net/${1}" ]; then
-    IP=$(ip addr show "${1}" scope global 2>/dev/null | grep -E "inet .* eth" | awk '{print $2}' | cut -d'/' -f1 | head -1)
+    IP=$(ip addr show "${1}" scope global 2>/dev/null | grep -E "inet .* (eth|wlan)" | awk '{print $2}' | cut -d'/' -f1 | head -1)
     [ -z "${IP}" ] && IP=$(ip route show dev "${1}" 2>/dev/null | sed -n 's/.* via .* src \(.*\) metric .*/\1/p' | head -1)
   else
-    IP=$(ip addr show scope global 2>/dev/null | grep -E "inet .* eth" | awk '{print $2}' | cut -d'/' -f1 | head -1)
+    IP=$(ip addr show scope global 2>/dev/null | grep -E "inet .* (eth|wlan)" | awk '{print $2}' | cut -d'/' -f1 | head -1)
     [ -z "${IP}" ] && IP=$(ip route show 2>/dev/null | sed -n 's/.* via .* src \(.*\) metric .*/\1/p' | head -1)
   fi
   echo "${IP}"
@@ -448,15 +484,21 @@ function delCmdline() {
 # check CPU Intel(VT-d)/AMD(AMD-Vi)
 function checkCPU_VT_d() {
   lsmod | grep -q msr || modprobe msr 2>/dev/null
+  local MSRVAL
+  # rdmsr prints bare hex with no 0x prefix. Bash arithmetic reads such a word as
+  # an identifier, so "ff07 & 0x5" is 0 and the check always reported VT-d off;
+  # a zero padded value like 0000000000000008 is instead parsed as octal and errors
+  # out. Add the prefix and reject anything that is not hex.
   if grep -q "GenuineIntel" /proc/cpuinfo 2>/dev/null; then
-    VT_D_ENABLED=$(rdmsr 0x3a 2>/dev/null)
-    [ "$((${VT_D_ENABLED:-0x0} & 0x5))" -eq $((0x5)) ] && return 0
+    MSRVAL="$(rdmsr 0x3a 2>/dev/null | tr -d '[:space:]')"
+    case "${MSRVAL}" in '' | *[!0-9A-Fa-f]*) return 1 ;; esac
+    [ "$((0x${MSRVAL} & 0x5))" -eq "$((0x5))" ] && return 0
   elif grep -q "AuthenticAMD" /proc/cpuinfo 2>/dev/null; then
-    IOMMU_ENABLED=$(rdmsr 0xC0010114 2>/dev/null)
-    [ "$((${IOMMU_ENABLED:-0x0} & 0x1))" -eq $((0x1)) ] && return 0
-  else
-    return 1
+    MSRVAL="$(rdmsr 0xC0010114 2>/dev/null | tr -d '[:space:]')"
+    case "${MSRVAL}" in '' | *[!0-9A-Fa-f]*) return 1 ;; esac
+    [ "$((0x${MSRVAL} & 0x1))" -eq "$((0x1))" ] && return 0
   fi
+  return 1
 }
 
 ###############################################################################

--- a/files/initrd/opt/rr/init.sh
+++ b/files/initrd/opt/rr/init.sh
@@ -121,9 +121,16 @@ if [ ! -f "/.dockerenv" ]; then
       if [ -n "${IPRA[2]}" ]; then
         ip route add default via "${IPRA[2]}" dev "${N}" 2>/dev/null || true
       fi
-      if [ -n "${IPRA[3]:-${IPRA[2]}}" ]; then
-        sed -i "/nameserver ${IPRA[3]:-${IPRA[2]}}/d" /etc/resolv.conf
-        echo "nameserver ${IPRA[3]:-${IPRA[2]}}" >>/etc/resolv.conf
+      DNSSRV="${IPRA[3]:-${IPRA[2]:-}}"
+      if [ -n "${DNSSRV}" ]; then
+        # With a static address udhcpc never runs, so /etc/resolv.conf may not exist
+        # yet. 'sed -i' on a missing file exits 2 and the 'set -e' above would abort
+        # the rest of the boot. Anchor the whole nameserver line so that deleting
+        # 192.168.1.1 does not also drop 192.168.1.100, and escape the dots with
+        # four backslashes: bash reduces "\\." in a replacement back to a bare dot.
+        touch /etc/resolv.conf 2>/dev/null || true
+        sed -i -E "/^[[:space:]]*nameserver[[:space:]]+${DNSSRV//./\\\\.}[[:space:]]*$/d" /etc/resolv.conf 2>/dev/null || true
+        echo "nameserver ${DNSSRV}" >>/etc/resolv.conf 2>/dev/null || true
       fi
       sleep 1
     fi

--- a/files/initrd/opt/rr/menu.sh
+++ b/files/initrd/opt/rr/menu.sh
@@ -1284,6 +1284,8 @@ function getSynoExtractor() {
   if [ $? -ne 0 ]; then
     echo -e "$(TEXT "The current network status is unknown, using the default mirror.")"
   fi
+  # _get_fastest echoes the first mirror when every measurement fails, so fastest is
+  # always a usable host and needs no further guard here.
   OLDPAT_URL="https://${fastest}/download/DSM/release/7.0.1/42218/DSM_DS3622xs%2B_42218.pat"
   OLDPAT_PATH="${TMP_PATH}/DS3622xs+-42218.pat"
   EXTRACTOR_PATH="${PART3_PATH}/extractor"
@@ -1424,11 +1426,15 @@ function extractDsmFiles() {
     mkdir -p "${PART3_PATH}/dl"
     mirrors=("global.synologydownload.com" "global.download.synology.com" "cndl.synology.cn")
     fastest=$(_get_fastest "${mirrors[@]}")
-    if [ $? -ne 0 ]; then
+    FASTESTRC=$?
+    if [ ${FASTESTRC} -ne 0 ]; then
       echo -e "$(TEXT "The current network status is unknown, using the default mirror.")"
     fi
     mirror="$(echo "${PATURL}" | sed 's|^http[s]*://\([^/]*\).*|\1|')"
-    if echo "${mirrors[@]}" | grep -wq "${mirror}" && [ ! "${mirror}" = "${fastest}" ]; then
+    # Only switch mirrors when a latency measurement actually succeeded. When ICMP is
+    # blocked _get_fastest falls back to the first mirror in the list, and rewriting
+    # the url to it would move the download off the one mirror the user can reach.
+    if [ ${FASTESTRC} -eq 0 ] && echo "${mirrors[@]}" | grep -wq "${mirror}" && [ ! "${mirror}" = "${fastest}" ]; then
       printf "$(TEXT "Based on the current network situation, switch to %s mirror to downloading.\n")" "${fastest}"
       PATURL="$(echo "${PATURL}" | sed "s/${mirror}/${fastest}/")"
     fi
@@ -2795,9 +2801,15 @@ function setStaticIP() {
                 if [ -n "${gateway}" ]; then
                   ip route add default via ${gateway} dev ${N}
                 fi
-                if [ -n "${dnsname:-${gateway}}" ]; then
-                  sed -i "/nameserver ${dnsname:-${gateway}}/d" /etc/resolv.conf
-                  echo "nameserver ${dnsname:-${gateway}}" >>/etc/resolv.conf
+                DNSSRV="${dnsname:-${gateway}}"
+                if [ -n "${DNSSRV}" ]; then
+                  # resolv.conf may not exist yet on a static-only box. Anchor the
+                  # whole nameserver line so that removing 192.168.1.1 does not also
+                  # remove 192.168.1.100, and escape the dots with four backslashes:
+                  # bash reduces "\\." in a replacement back to a bare dot.
+                  touch /etc/resolv.conf 2>/dev/null || true
+                  sed -i -E "/^[[:space:]]*nameserver[[:space:]]+${DNSSRV//./\\\\.}[[:space:]]*$/d" /etc/resolv.conf 2>/dev/null || true
+                  echo "nameserver ${DNSSRV}" >>/etc/resolv.conf 2>/dev/null || true
                 fi
               fi
               writeConfigKey "network.${MACR}" "${address}/${netmask}/${gateway}/${dnsname}" "${USER_CONFIG_FILE}"
@@ -3915,7 +3927,10 @@ function updateCKs() {
 ###############################################################################
 # 1 - update file
 function checkUpdateFile() {
-  F="$(ls ${PART3_PATH}/${1}*.zip ${TMP_PATH}/${1}*.zip 2>/dev/null | sort -V | tail -n 1)"
+  # Downloads are named "<name>-<tag>.zip", so a bare "${1}*" glob makes the "update"
+  # entry pick up "updateall-*.zip" as well. Anchor the name so each menu entry only
+  # ever sees its own archive.
+  F="$(ls ${PART3_PATH}/${1}*.zip ${TMP_PATH}/${1}*.zip 2>/dev/null | grep -E "/${1}(-[^/]*)?\.zip$" | sort -V | tail -n 1)"
   [ -n "${F}" ] && [ -f "${F}.downloading" ] && {
     rm -f "${F}" "${F}.downloading" >/dev/null 2>&1
     F=""

--- a/files/initrd/opt/rr/ramdisk-patch.sh
+++ b/files/initrd/opt/rr/ramdisk-patch.sh
@@ -54,13 +54,24 @@ echo -n "Patching Ramdisk"
 # Unzipping ramdisk
 rm -rf "${RAMDISK_PATH}" # Force clean
 mkdir -p "${RAMDISK_PATH}"
-(cd "${RAMDISK_PATH}" && xz -dc <"${ORI_RDGZ_FILE}" | cpio -idm) >/dev/null 2>&1
+if ! (cd "${RAMDISK_PATH}" && xz -dc <"${ORI_RDGZ_FILE}" | cpio -idm) >/dev/null 2>&1; then
+  echo "ERROR: Failed to extract ${ORI_RDGZ_FILE}!" >"${LOG_FILE}"
+  exit 1
+fi
 
-# Check if DSM buildnumber changed
+# Check if DSM buildnumber changed. Without 'set -e' a failed extraction above used
+# to fall through to here, leave buildnumber unset, and overwrite the good buildnum
+# in the user config with 0 - which then re-enables patches meant for old builds.
+if [ ! -f "${RAMDISK_PATH}/etc/VERSION" ]; then
+  echo "ERROR: ${RAMDISK_PATH}/etc/VERSION not found, ramdisk extraction failed!" >"${LOG_FILE}"
+  exit 1
+fi
 . "${RAMDISK_PATH}/etc/VERSION"
 
 BUILDNUM=${buildnumber:-0}
 SMALLNUM=${smallfixnumber:-0}
+case "${BUILDNUM}" in '' | *[!0-9]*) BUILDNUM=0 ;; esac
+case "${SMALLNUM}" in '' | *[!0-9]*) SMALLNUM=0 ;; esac
 writeConfigKey "buildnum" "${BUILDNUM}" "${USER_CONFIG_FILE}"
 writeConfigKey "smallnum" "${SMALLNUM}" "${USER_CONFIG_FILE}"
 


### PR DESCRIPTION
Found these while reading through the boot and network code. Each one is described with the condition that triggers it.

### `checkCPU_VT_d` never detects VT-d

`rdmsr` prints bare hex with no `0x` prefix, so bash arithmetic reads the word as an identifier:

```
$ VT_D_ENABLED=ff07; echo $((${VT_D_ENABLED:-0x0} & 0x5))
0
```

The check reports VT-d disabled on every Intel machine. A zero-padded value goes the other way and fails outright:

```
$ VT_D_ENABLED=0000000000000008; echo $((${VT_D_ENABLED:-0x0} & 0x5))
bash: 0000000000000008: value too great for base (error token is "0000000000000008")
```

Added the `0x` prefix and a hex validation. The `& 0x5` semantics are unchanged (bit 0 lock + bit 2 VMX outside SMX).

### `__setHosts` deletes unrelated hosts

`${DOMAIN//./\.}` does not escape anything — bash reduces `\.` in the replacement to a bare dot, so the dots reach sed as wildcards:

```
$ DOMAIN=www.synology.com; echo "/[[:space:]]${DOMAIN//./\.}[[:space:]]*$/d"
/[[:space:]]www.synology.com[[:space:]]*$/d
```

Pinning `www.synology.com` removes `9.9.9.9 wwwXsynologyYcom`, and the `[[:space:]]*$` anchor misses rows where the domain is followed by an alias, so a stale entry survives and shadows the new one. Replaced with a field comparison in awk; comment lines are preserved. Same fix applied to the Python copy in `functions.py`.

### `_sort_netif` can abort the boot

`init.sh` runs with `set -e`, where a failing command substitution inside an assignment terminates the script. `grep` exits 1 when a `sortnetif` mac does not match any interface, which kills the boot before the network is configured.

Separately, `echo -e "" | wc -l` is 1, so `ETHNUM` was 1 with no interfaces at all and the rename loop ran `ip link set dev eth0 name tmp0` against a device that does not exist. Switched to an awk counter, which still exits 0 on a zero count.

### `writeConfigKey` loses writes containing a quote

The value is interpolated into the yq expression, so a quote in a serial, password or webhook url produces `.key = "pa"ss"`. yq fails, stderr is redirected to `/dev/null`, and the write is silently lost. `strenv()` passes the value through as data.

### `checkUpdateFile` picks up the wrong archive

Downloads are named `<name>-<tag>.zip`, so the bare `${1}*` glob makes the `update` entry match `updateall-*.zip`. With only `updateall-25.7.1.zip` present, `checkUpdateFile "update"` returns the all-in-one archive and it gets installed as an RR-only update. Anchored the name.

### Smaller ones

- `_resolve_and_set_hosts`: `ping -W` only bounds the ICMP reply wait, not the name lookup. With a dead nameserver `getaddrinfo` blocks for roughly 10s before ping starts, delaying the DoH fallback. Wrapped in `timeout`.
- `_get_fastest`: a non-numeric measurement was reported as success.
- `extractDsmFiles`: only switch mirrors when a measurement actually succeeded. When ICMP is blocked `_get_fastest` falls back to the first mirror, and rewriting the url to it moves the download off the one mirror the user can reach.
- `ramdisk-patch.sh`: the script has no `set -e`, so a failed extraction fell through, left `buildnumber` unset and overwrote a good `buildnum` with 0, which re-enables patches meant for older builds. Bail out instead.
- `init.sh` / `setStaticIP`: with a static address udhcpc never runs and `/etc/resolv.conf` may not exist, where `sed -i` exits 2 and aborts the boot under `set -e`. The nameserver line is now anchored so removing 192.168.1.1 does not also drop 192.168.1.100.
- `getIP`: also match `wlan`. `init.sh` brings wireless interfaces up via `connectwlanif`, but `getIP` only matched `eth`, so the address never showed up in the QR code or webhook payload.

### Testing

`bash -n` on every touched script and `py_compile` on `functions.py`. The hosts rewriting, interface ordering, resolv.conf matching, mirror selection and MSR parsing were each exercised against the extracted logic, including empty and missing input files. No DSM install was tested end to end, so the ramdisk and static-IP paths would benefit from a second look.